### PR TITLE
Bind /dev/usb so USB peripherals can be accessed from within the container (for adb and fastboot)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -31,7 +31,7 @@ if [[ $IS_RUNNING == "true" ]]; then
 elif [[ $IS_RUNNING == "false" ]]; then
 	docker start -i $CONTAINER
 else
-	docker run -v $SOURCE:$CONTAINER_HOME/android -v $CCACHE:/srv/ccache -i -t --name $CONTAINER $REPOSITORY sh -c "screen -s /bin/bash"
+	docker run --privileged -v /dev/bus/usb:/dev/bus/usb -v $SOURCE:$CONTAINER_HOME/android -v $CCACHE:/srv/ccache -i -t --name $CONTAINER $REPOSITORY sh -c "screen -s /bin/bash"
 fi
 
 exit $?


### PR DESCRIPTION
This is very helpful when copying proprietary blobs from a phone for instance, or when you want to boot a freshly built kernel using fastboot.

Unfortunately, this means we have to start the container as privileged.